### PR TITLE
Better support for expansions

### DIFF
--- a/src/main/java/com/wildcard/buddycards/block/BuddycardBoosterBoxBlock.java
+++ b/src/main/java/com/wildcard/buddycards/block/BuddycardBoosterBoxBlock.java
@@ -37,7 +37,7 @@ public class BuddycardBoosterBoxBlock extends Block {
         REQUIREMENT = shouldLoad;
     }
 
-    final BuddycardsItems.BuddycardRequirement REQUIREMENT;
+    protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
 
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter blockReader, BlockPos pos, CollisionContext context) {

--- a/src/main/java/com/wildcard/buddycards/client/renderer/MedalRenderer.java
+++ b/src/main/java/com/wildcard/buddycards/client/renderer/MedalRenderer.java
@@ -16,8 +16,8 @@ import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.client.ICurioRenderer;
 
 public class MedalRenderer implements ICurioRenderer {
-    public MedalRenderer(String name) {
-        texture = new ResourceLocation(Buddycards.MOD_ID, "textures/models/medal/" + name + ".png");
+    public MedalRenderer(ResourceLocation texture) {
+        this.texture = texture;
     }
 
     private final ResourceLocation texture;

--- a/src/main/java/com/wildcard/buddycards/core/BuddycardSet.java
+++ b/src/main/java/com/wildcard/buddycards/core/BuddycardSet.java
@@ -1,0 +1,62 @@
+package com.wildcard.buddycards.core;
+
+import com.wildcard.buddycards.Buddycards;
+import com.wildcard.buddycards.item.BuddycardItem;
+import com.wildcard.buddycards.item.BuddysteelSetMedalItem;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class BuddycardSet {
+
+    protected final List<BuddycardItem> cards = new ArrayList<>();
+    protected final String name;
+
+    @Nullable
+    protected Supplier<BuddysteelSetMedalItem> medalSupplier;
+
+    @Nullable
+    protected String descriptionId;
+
+    public BuddycardSet(String name) {
+        this.name = name;
+        BuddycardsAPI.registerSet(this);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescriptionId() {
+        if (descriptionId == null) {
+            descriptionId = "item." + Buddycards.MOD_ID + ".buddycard.set_" + getName();
+        }
+
+        return descriptionId;
+    }
+
+    public void setMedal(Supplier<BuddysteelSetMedalItem> supplier) {
+        this.medalSupplier = supplier;
+    }
+
+    @Nullable
+    public BuddysteelSetMedalItem getMedal() {
+        if (medalSupplier == null) {
+            return null;
+        }
+
+        return medalSupplier.get();
+    }
+
+    public void addCard(BuddycardItem card) {
+        cards.add(card);
+    }
+
+    public Collection<BuddycardItem> getCards() {
+        return Collections.unmodifiableCollection(cards);
+    }
+}

--- a/src/main/java/com/wildcard/buddycards/core/BuddycardsAPI.java
+++ b/src/main/java/com/wildcard/buddycards/core/BuddycardsAPI.java
@@ -1,0 +1,36 @@
+package com.wildcard.buddycards.core;
+
+import com.wildcard.buddycards.item.BuddycardItem;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class BuddycardsAPI {
+    private static final List<BuddycardItem> CARDS = new ArrayList<>();
+    private static final List<BuddycardSet> CARD_SETS = new ArrayList<>();
+
+    public static void registerCard(BuddycardItem card) {
+        CARDS.add(card);
+        card.getSet().addCard(card);
+    }
+
+    public static void registerSet(BuddycardSet set) {
+        for (BuddycardSet cardSet : CARD_SETS) {
+            if (cardSet.getName().equalsIgnoreCase(set.getName())) {
+                throw new IllegalArgumentException("Set '" + set.getName() + "' already exists");
+            }
+        }
+
+        CARD_SETS.add(set);
+    }
+
+    public static Collection<BuddycardItem> getAllCards() {
+        return Collections.unmodifiableCollection(CARDS);
+    }
+
+    public static Collection<BuddycardSet> getAllCardsets() {
+        return Collections.unmodifiableCollection(CARD_SETS);
+    }
+}

--- a/src/main/java/com/wildcard/buddycards/datagen/CardModelGen.java
+++ b/src/main/java/com/wildcard/buddycards/datagen/CardModelGen.java
@@ -1,6 +1,8 @@
 package com.wildcard.buddycards.datagen;
 
 import com.wildcard.buddycards.Buddycards;
+import com.wildcard.buddycards.core.BuddycardSet;
+import com.wildcard.buddycards.core.BuddycardsAPI;
 import com.wildcard.buddycards.item.BuddycardItem;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.resources.ResourceLocation;
@@ -17,17 +19,18 @@ public class CardModelGen extends ItemModelProvider {
 
     @Override
     protected void registerModels() {
-        for (BuddycardItem card: BuddycardItem.CARDS)
+        for (BuddycardItem card: BuddycardsAPI.getAllCards())
             genCardModel(card.getSet(), card.getCardNumber());
 
     }
 
     /**
      * Makes every model for a card, including all grades for normal and shiny cards
-     * @param setName set of card to generate models for
+     * @param set set of card to generate models for
      * @param cardNum card number of card to generate models for
      */
-    void genCardModel(String setName, int cardNum) {
+    void genCardModel(BuddycardSet set, int cardNum) {
+        String setName = set.getName();
         final ResourceLocation location = new ResourceLocation(Buddycards.MOD_ID, ModelProvider.ITEM_FOLDER + "/buddycard_" + setName + cardNum);
         ItemModelBuilder card = factory.apply(location)
                 .parent(factory.apply(new ResourceLocation(Buddycards.MOD_ID, ModelProvider.ITEM_FOLDER + "/buddycard")))

--- a/src/main/java/com/wildcard/buddycards/item/BlankBuddysteelMedalItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BlankBuddysteelMedalItem.java
@@ -34,10 +34,11 @@ public class BlankBuddysteelMedalItem extends Item {
         ItemStack stack = player.getItemInHand(hand);
         InteractionHand cardHand = hand == InteractionHand.MAIN_HAND ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
         if(level instanceof ServerLevel serverLevel && stack.getItem() instanceof BlankBuddysteelMedalItem && player.getItemInHand(cardHand).getItem() instanceof BuddycardItem card) {
-            if(BuddysteelSetMedalItem.MEDALS.containsKey(card.getSet()) && BuddysteelSetMedalItem.MEDALS.get(card.getSet()).REQUIREMENT.shouldLoad()) {
+            BuddysteelSetMedalItem medalItem = card.getSet().getMedal();
+            if(medalItem != null && medalItem.REQUIREMENT.shouldLoad()) {
                 if (BuddycardCollectionSaveData.get(serverLevel).checkPlayerSetCompleted(player.getUUID(), card.getSet())) {
-                    player.displayClientMessage(new TranslatableComponent("item.buddycards.blank_buddysteel_medal.success").append(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.set_" + card.getSet())), true);
-                    ItemStack medal = new ItemStack(BuddysteelSetMedalItem.MEDALS.get(card.getSet()));
+                    player.displayClientMessage(new TranslatableComponent("item.buddycards.blank_buddysteel_medal.success").append(new TranslatableComponent(card.getSet().getDescriptionId())), true);
+                    ItemStack medal = new ItemStack(medalItem);
                     CompoundTag nbt = new CompoundTag();
                     nbt.putString("player", player.getName().getString());
                     nbt.putInt("day", (int)(level.getDayTime()/24000));

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardBinderItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardBinderItem.java
@@ -25,7 +25,7 @@ public class BuddycardBinderItem extends Item {
         REQUIREMENT = shouldLoad;
     }
 
-    BuddycardsItems.BuddycardRequirement REQUIREMENT;
+    protected BuddycardsItems.BuddycardRequirement REQUIREMENT;
 
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardBoosterBoxItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardBoosterBoxItem.java
@@ -19,7 +19,7 @@ public class BuddycardBoosterBoxItem extends BlockItem {
         SET = set;
     }
 
-    final String SET;
+    protected final String SET;
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardBoosterBoxItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardBoosterBoxItem.java
@@ -1,6 +1,7 @@
 package com.wildcard.buddycards.item;
 
 import com.wildcard.buddycards.Buddycards;
+import com.wildcard.buddycards.core.BuddycardSet;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
@@ -12,17 +13,20 @@ import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 public class BuddycardBoosterBoxItem extends BlockItem {
-    public BuddycardBoosterBoxItem(Block block, String set, Properties properties) {
+
+
+    public BuddycardBoosterBoxItem(Block block, Supplier<BuddycardPackItem> packSupplier, Properties properties) {
         super(block, properties);
-        SET = set;
+        this.packSupplier = packSupplier;
     }
 
-    protected final String SET;
+    protected final Supplier<BuddycardPackItem> packSupplier;
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {
-        tooltip.add(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.set_" + SET).withStyle(ChatFormatting.GRAY));
+        packSupplier.get().appendHoverText(stack, level, tooltip, flag);
     }
 }

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardItem.java
@@ -31,10 +31,10 @@ public class BuddycardItem extends Item {
         CARDS.add(this);
     }
 
-    private final String SET;
-    private final int CARD_NUMBER;
-    private final Rarity RARITY;
-    private final BuddycardsItems.BuddycardRequirement REQUIREMENT;
+    protected final String SET;
+    protected final int CARD_NUMBER;
+    protected final Rarity RARITY;
+    protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardItem.java
@@ -1,6 +1,8 @@
 package com.wildcard.buddycards.item;
 
 import com.wildcard.buddycards.Buddycards;
+import com.wildcard.buddycards.core.BuddycardsAPI;
+import com.wildcard.buddycards.core.BuddycardSet;
 import com.wildcard.buddycards.registries.BuddycardsItems;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.NonNullList;
@@ -16,22 +18,19 @@ import java.util.HashMap;
 import java.util.List;
 
 public class BuddycardItem extends Item {
-    public static ArrayList<BuddycardItem> CARDS = new ArrayList<>();
-    public static HashMap<String, ArrayList<BuddycardItem>> CARD_LIST = new HashMap<>();
+//    public static HashMap<String, ArrayList<BuddycardItem>> CARD_LIST = new HashMap<>();
 
-    public BuddycardItem(BuddycardsItems.BuddycardRequirement shouldLoad, String set, int cardNumber, Rarity rarity, Item.Properties properties) {
+    public BuddycardItem(BuddycardsItems.BuddycardRequirement shouldLoad, BuddycardSet set, int cardNumber, Rarity rarity, Item.Properties properties) {
         super(properties);
         SET = set;
         CARD_NUMBER = cardNumber;
         RARITY = rarity;
         REQUIREMENT = shouldLoad;
-        if(!CARD_LIST.containsKey(SET))
-            CARD_LIST.put(SET, new ArrayList<>());
-        CARD_LIST.get(SET).add(this);
-        CARDS.add(this);
+
+        BuddycardsAPI.registerCard(this);
     }
 
-    protected final String SET;
+    protected final BuddycardSet SET;
     protected final int CARD_NUMBER;
     protected final Rarity RARITY;
     protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
@@ -45,7 +44,7 @@ public class BuddycardItem extends Item {
         cn.append("" + CARD_NUMBER);
         if(isFoil(stack))
             cn.append(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.foil_symbol"));
-        tooltip.add(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.set_" + SET).append(cn).withStyle(ChatFormatting.GRAY));
+        tooltip.add(new TranslatableComponent(SET.getDescriptionId()).append(cn).withStyle(ChatFormatting.GRAY));
         if(stack.hasTag() && stack.getTag().contains("grade")) {
             tooltip.add(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.grade." + stack.getTag().getInt("grade")).withStyle(ChatFormatting.GRAY));
         }
@@ -60,7 +59,7 @@ public class BuddycardItem extends Item {
         return RARITY;
     }
 
-    public String getSet() {
+    public BuddycardSet getSet() {
         return SET;
     }
 

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardPackItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardPackItem.java
@@ -1,6 +1,6 @@
 package com.wildcard.buddycards.item;
 
-import com.wildcard.buddycards.Buddycards;
+import com.wildcard.buddycards.core.BuddycardSet;
 import com.wildcard.buddycards.registries.BuddycardsItems;
 import com.wildcard.buddycards.savedata.BuddycardCollectionSaveData;
 import net.minecraft.ChatFormatting;
@@ -21,10 +21,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
-public class BuddycardPackItem extends Item {
-    public BuddycardPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, String set, int amount, int foils, SimpleWeightedRandomList<Rarity> rarityWeights, Properties properties) {
+public abstract class BuddycardPackItem extends Item {
+    public BuddycardPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, int amount, int foils, SimpleWeightedRandomList<Rarity> rarityWeights, Properties properties) {
         super(properties);
-        SET = set;
         REQUIREMENT = shouldLoad;
         CARD_AMT = amount;
         FOIL_AMT = foils;
@@ -35,16 +34,10 @@ public class BuddycardPackItem extends Item {
         }
     }
 
-    protected final String SET;
     protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
     protected final int CARD_AMT;
     protected final int FOIL_AMT;
     protected final SimpleWeightedRandomList<Rarity> rarityWeights;
-
-    @Override
-    public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {
-        tooltip.add(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.set_" + SET).withStyle(ChatFormatting.GRAY));
-    }
 
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
@@ -83,14 +76,8 @@ public class BuddycardPackItem extends Item {
         return optional
                 .map(this::getPossibleCards)
                 .map(cards -> cards.get(random.nextInt(cards.size())))
-                .orElseThrow(() -> new IllegalStateException("Cardset " + SET + " does not contain cards for rarity"));
+                .orElseThrow(() -> new IllegalStateException("Cardpack " + getRegistryName() + " does not contain cards for rarity"));
     }
 
-    protected List<BuddycardItem> getPossibleCards(Rarity rarity) {
-        return BuddycardItem.CARD_LIST
-                .get(SET)
-                .stream()
-                .filter(card -> card.getRarity() == rarity)
-                .toList();
-    }
+    public abstract List<BuddycardItem> getPossibleCards(Rarity rarity);
 }

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardPackItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardPackItem.java
@@ -33,10 +33,10 @@ public class BuddycardPackItem extends Item {
         FOIL_AMT = foils;
     }
 
-    private final String SET;
-    private final BuddycardsItems.BuddycardRequirement REQUIREMENT;
-    private final int CARD_AMT;
-    private final int FOIL_AMT;
+    protected final String SET;
+    protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
+    protected final int CARD_AMT;
+    protected final int FOIL_AMT;
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardPackItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardPackItem.java
@@ -1,8 +1,6 @@
 package com.wildcard.buddycards.item;
 
 import com.wildcard.buddycards.Buddycards;
-import com.wildcard.buddycards.block.BuddycardBoosterBoxBlock;
-import com.wildcard.buddycards.registries.BuddycardsBlocks;
 import com.wildcard.buddycards.registries.BuddycardsItems;
 import com.wildcard.buddycards.savedata.BuddycardCollectionSaveData;
 import net.minecraft.ChatFormatting;
@@ -10,33 +8,38 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.random.SimpleWeightedRandomList;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
 public class BuddycardPackItem extends Item {
-    public BuddycardPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, String set, int amount, int foils, Properties properties) {
+    public BuddycardPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, String set, int amount, int foils, SimpleWeightedRandomList<Rarity> rarityWeights, Properties properties) {
         super(properties);
         SET = set;
         REQUIREMENT = shouldLoad;
         CARD_AMT = amount;
         FOIL_AMT = foils;
+        this.rarityWeights = rarityWeights;
+
+        if (this.rarityWeights.isEmpty()) {
+            throw new IllegalArgumentException("No rarity weights provided");
+        }
     }
 
     protected final String SET;
     protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
     protected final int CARD_AMT;
     protected final int FOIL_AMT;
+    protected final SimpleWeightedRandomList<Rarity> rarityWeights;
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {
@@ -45,7 +48,7 @@ public class BuddycardPackItem extends Item {
 
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
-        if(level instanceof ServerLevel serverLevel) {
+        if (level instanceof ServerLevel serverLevel) {
             //Prematurely delete the pack item so the card items can go in the same slot
             player.getItemInHand(hand).shrink(1);
             //Roll each card and throw it into a list
@@ -53,14 +56,14 @@ public class BuddycardPackItem extends Item {
             for (int i = 0; i < CARD_AMT; i++) {
                 ItemStack card = new ItemStack(rollCard(level.getRandom()));
                 //If its one of the last ones that needs foil, make it foil
-                if(i >= CARD_AMT - FOIL_AMT)
+                if (i >= CARD_AMT - FOIL_AMT)
                     BuddycardItem.setShiny(card);
                 cards.add(card);
             }
             //Give each card to the player and put their collection data in
             cards.forEach((card) -> {
                 ItemHandlerHelper.giveItemToPlayer(player, card);
-                BuddycardCollectionSaveData.get(serverLevel).addPlayerCardFound(player.getUUID(), ((BuddycardItem)card.getItem()).getSet(), ((BuddycardItem)card.getItem()).getCardNumber());
+                BuddycardCollectionSaveData.get(serverLevel).addPlayerCardFound(player.getUUID(), ((BuddycardItem) card.getItem()).getSet(), ((BuddycardItem) card.getItem()).getCardNumber());
             });
         }
         //Return success every time because we shrink it ourselves instead of using consume
@@ -70,27 +73,24 @@ public class BuddycardPackItem extends Item {
     @Override
     public void fillItemCategory(CreativeModeTab group, NonNullList<ItemStack> items) {
         //Only show in the creative menu when the respective mod is loaded
-        if(this.allowdedIn(group) && REQUIREMENT.shouldLoad()) {
+        if (this.allowdedIn(group) && REQUIREMENT.shouldLoad()) {
             items.add(new ItemStack(this));
         }
     }
 
     public BuddycardItem rollCard(Random random) {
-        float rand = random.nextFloat();
-        Rarity rarity;
-        if (rand < .6)
-            rarity = Rarity.COMMON;
-        else if (rand < .9)
-            rarity = Rarity.UNCOMMON;
-        else if (rand < .975)
-            rarity = Rarity.RARE;
-        else
-            rarity = Rarity.EPIC;
-        ArrayList<BuddycardItem> set = BuddycardItem.CARD_LIST.get(SET);
-        BuddycardItem card = set.get((int) (random.nextFloat() * set.size()));
-        while (card.getRarity() != rarity) {
-            card = set.get((int) (random.nextFloat() * set.size()));
-        }
-        return card;
+        Optional<Rarity> optional = rarityWeights.getRandomValue(random);
+        return optional
+                .map(this::getPossibleCards)
+                .map(cards -> cards.get(random.nextInt(cards.size())))
+                .orElseThrow(() -> new IllegalStateException("Cardset " + SET + " does not contain cards for rarity"));
+    }
+
+    protected List<BuddycardItem> getPossibleCards(Rarity rarity) {
+        return BuddycardItem.CARD_LIST
+                .get(SET)
+                .stream()
+                .filter(card -> card.getRarity() == rarity)
+                .toList();
     }
 }

--- a/src/main/java/com/wildcard/buddycards/item/BuddycardSetPackItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddycardSetPackItem.java
@@ -1,7 +1,6 @@
 package com.wildcard.buddycards.item;
 
-import com.wildcard.buddycards.Buddycards;
-import com.wildcard.buddycards.core.BuddycardsAPI;
+import com.wildcard.buddycards.core.BuddycardSet;
 import com.wildcard.buddycards.registries.BuddycardsItems;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -15,24 +14,23 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class MysteryBuddycardPackItem extends BuddycardPackItem {
-    public MysteryBuddycardPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, int amount, int foils, SimpleWeightedRandomList<Rarity> rarityWeights, boolean includeUnloaded, Properties properties) {
+public class BuddycardSetPackItem extends BuddycardPackItem {
+    public BuddycardSetPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, BuddycardSet set, int amount, int foils, SimpleWeightedRandomList<Rarity> rarityWeights, Properties properties) {
         super(shouldLoad, amount, foils, rarityWeights, properties);
-        INCLUDE_UNLOADED = includeUnloaded;
+        SET = set;
     }
 
-    protected final boolean INCLUDE_UNLOADED;
+    protected final BuddycardSet SET;
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {
-        tooltip.add(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.set_mystery").withStyle(ChatFormatting.GRAY));
+        tooltip.add(new TranslatableComponent(SET.getDescriptionId()).withStyle(ChatFormatting.GRAY));
     }
 
-    @Override
     public List<BuddycardItem> getPossibleCards(Rarity rarity) {
-        return BuddycardsAPI.getAllCards()
+        return SET.getCards()
                 .stream()
-                .filter(card -> card.getRarity() == rarity && card.shouldBeInMysteryPacks())
+                .filter(card -> card.getRarity() == rarity)
                 .toList();
     }
 }

--- a/src/main/java/com/wildcard/buddycards/item/BuddysteelPowerMeterItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddysteelPowerMeterItem.java
@@ -32,7 +32,7 @@ public class BuddysteelPowerMeterItem extends Item {
             if(player.getItemInHand(cardHand).getItem() instanceof BuddycardItem card) {
                 //Specific set
                 BuddycardCollectionSaveData.Fraction cardsCollected = BuddycardCollectionSaveData.get(serverLevel).checkPlayerSetCompletion(player.getUUID(), card.getSet());
-                player.displayClientMessage(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.set_" + card.getSet())
+                player.displayClientMessage(new TranslatableComponent(card.getSet().getDescriptionId())
                         .append(new TranslatableComponent("item.buddycards.buddysteel_power_meter.cards_collected"))
                         .append(cardsCollected.top + "/" + cardsCollected.bottom), true);
             }

--- a/src/main/java/com/wildcard/buddycards/item/BuddysteelSetMedalItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddysteelSetMedalItem.java
@@ -1,6 +1,7 @@
 package com.wildcard.buddycards.item;
 
 import com.wildcard.buddycards.Buddycards;
+import com.wildcard.buddycards.core.BuddycardSet;
 import com.wildcard.buddycards.registries.BuddycardsItems;
 import com.wildcard.buddycards.util.CuriosIntegration;
 import net.minecraft.ChatFormatting;
@@ -19,13 +20,11 @@ import java.util.HashMap;
 import java.util.List;
 
 public class BuddysteelSetMedalItem extends MedalItem {
-    public static final HashMap<String, BuddysteelSetMedalItem> MEDALS = new HashMap<>();
-
-    public BuddysteelSetMedalItem(BuddycardsItems.BuddycardRequirement shouldLoad, IMedalTypes type, String set, Item.Properties properties) {
+    public BuddysteelSetMedalItem(BuddycardsItems.BuddycardRequirement shouldLoad, IMedalTypes type, BuddycardSet set, Item.Properties properties) {
         super(type, properties);
         this.REQUIREMENT = shouldLoad;
         this.SET = set;
-        MEDALS.put(set, this);
+        this.SET.setMedal(() -> this);
     }
 
     @Override
@@ -38,13 +37,13 @@ public class BuddysteelSetMedalItem extends MedalItem {
                     .withStyle(ChatFormatting.GRAY));
             tooltip.add(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddysteel_medal.set")
                     .withStyle(ChatFormatting.GRAY));
-            tooltip.add(new TranslatableComponent("item." + Buddycards.MOD_ID + ".buddycard.set_" + SET)
+            tooltip.add(new TranslatableComponent(SET.getDescriptionId())
                     .withStyle(ChatFormatting.GRAY));
         }
     }
 
     protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
-    protected final String SET;
+    protected final BuddycardSet SET;
 
     @Override
     public ICapabilityProvider initCapabilities(final ItemStack stack, CompoundTag unused) {

--- a/src/main/java/com/wildcard/buddycards/item/BuddysteelSetMedalItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/BuddysteelSetMedalItem.java
@@ -43,8 +43,8 @@ public class BuddysteelSetMedalItem extends MedalItem {
         }
     }
 
-    final BuddycardsItems.BuddycardRequirement REQUIREMENT;
-    final String SET;
+    protected final BuddycardsItems.BuddycardRequirement REQUIREMENT;
+    protected final String SET;
 
     @Override
     public ICapabilityProvider initCapabilities(final ItemStack stack, CompoundTag unused) {

--- a/src/main/java/com/wildcard/buddycards/item/MedalItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/MedalItem.java
@@ -12,7 +12,7 @@ public class MedalItem extends Item implements ICurioItem {
         super(properties);
         this.TYPE = type;
     }
-    final IMedalTypes TYPE;
+    protected final IMedalTypes TYPE;
 
     @Override
     public ICapabilityProvider initCapabilities(final ItemStack stack, CompoundTag unused) {

--- a/src/main/java/com/wildcard/buddycards/item/MysteryBuddycardPackItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/MysteryBuddycardPackItem.java
@@ -11,7 +11,7 @@ public class MysteryBuddycardPackItem extends BuddycardPackItem{
         INCLUDE_UNLOADED = includeUnloaded;
     }
 
-    final boolean INCLUDE_UNLOADED;
+    protected final boolean INCLUDE_UNLOADED;
 
     @Override
     public BuddycardItem rollCard(Random random) {

--- a/src/main/java/com/wildcard/buddycards/item/MysteryBuddycardPackItem.java
+++ b/src/main/java/com/wildcard/buddycards/item/MysteryBuddycardPackItem.java
@@ -1,34 +1,24 @@
 package com.wildcard.buddycards.item;
 
 import com.wildcard.buddycards.registries.BuddycardsItems;
+import net.minecraft.util.random.SimpleWeightedRandomList;
 import net.minecraft.world.item.Rarity;
 
-import java.util.Random;
+import java.util.List;
 
-public class MysteryBuddycardPackItem extends BuddycardPackItem{
-    public MysteryBuddycardPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, int amount, int foils, boolean includeUnloaded, Properties properties) {
-        super(shouldLoad, "mystery", amount, foils, properties);
+public class MysteryBuddycardPackItem extends BuddycardPackItem {
+    public MysteryBuddycardPackItem(BuddycardsItems.BuddycardRequirement shouldLoad, int amount, int foils, SimpleWeightedRandomList<Rarity> rarityWeights, boolean includeUnloaded, Properties properties) {
+        super(shouldLoad, "mystery", amount, foils, rarityWeights, properties);
         INCLUDE_UNLOADED = includeUnloaded;
     }
 
     protected final boolean INCLUDE_UNLOADED;
 
     @Override
-    public BuddycardItem rollCard(Random random) {
-        float rand = random.nextFloat();
-        Rarity rarity;
-        if (rand < .6)
-            rarity = Rarity.COMMON;
-        else if (rand < .9)
-            rarity = Rarity.UNCOMMON;
-        else if (rand < .975)
-            rarity = Rarity.RARE;
-        else
-            rarity = Rarity.EPIC;
-        BuddycardItem card = BuddycardItem.CARDS.get((int) (random.nextFloat() *  BuddycardItem.CARDS.size()));
-        while (card.getRarity() != rarity || !card.shouldBeInMysteryPacks()) {
-            card =  BuddycardItem.CARDS.get((int) (random.nextFloat() *  BuddycardItem.CARDS.size()));
-        }
-        return card;
+    protected List<BuddycardItem> getPossibleCards(Rarity rarity) {
+        return BuddycardItem.CARDS
+                .stream()
+                .filter(card -> card.getRarity() == rarity && card.shouldBeInMysteryPacks())
+                .toList();
     }
 }

--- a/src/main/java/com/wildcard/buddycards/registries/BuddycardsBlocks.java
+++ b/src/main/java/com/wildcard/buddycards/registries/BuddycardsBlocks.java
@@ -11,7 +11,13 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
 public class BuddycardsBlocks {
+    public static final List<Supplier<CardDisplayBlock>> DISPLAY_BLOCKS = new ArrayList<>();
+
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, Buddycards.MOD_ID);
 
     public static void registerBlocks() {
@@ -23,18 +29,23 @@ public class BuddycardsBlocks {
     //Basic Blocks
     public static final RegistryObject<Block> BUDDYSTEEL_BLOCK = BLOCKS.register("buddysteel_block", () -> new Block(BlockBehaviour.Properties.copy(Blocks.LAPIS_BLOCK)));
     //Displays
-    public static final RegistryObject<Block> OAK_CARD_DISPLAY = BLOCKS.register("oak_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS)));
-    public static final RegistryObject<Block> SPRUCE_CARD_DISPLAY = BLOCKS.register("spruce_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.SPRUCE_PLANKS)));
-    public static final RegistryObject<Block> BIRCH_CARD_DISPLAY = BLOCKS.register("birch_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.BIRCH_PLANKS)));
-    public static final RegistryObject<Block> JUNGLE_CARD_DISPLAY = BLOCKS.register("jungle_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.JUNGLE_PLANKS)));
-    public static final RegistryObject<Block> ACACIA_CARD_DISPLAY = BLOCKS.register("acacia_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.ACACIA_PLANKS)));
-    public static final RegistryObject<Block> DARK_OAK_CARD_DISPLAY = BLOCKS.register("dark_oak_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.DARK_OAK_PLANKS)));
-    public static final RegistryObject<Block> CRIMSON_CARD_DISPLAY = BLOCKS.register("crimson_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.CRIMSON_PLANKS)));
-    public static final RegistryObject<Block> WARPED_CARD_DISPLAY = BLOCKS.register("warped_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.WARPED_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> OAK_CARD_DISPLAY = registerDisplay("oak_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> SPRUCE_CARD_DISPLAY = registerDisplay("spruce_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.SPRUCE_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> BIRCH_CARD_DISPLAY = registerDisplay("birch_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.BIRCH_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> JUNGLE_CARD_DISPLAY = registerDisplay("jungle_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.JUNGLE_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> ACACIA_CARD_DISPLAY = registerDisplay("acacia_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.ACACIA_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> DARK_OAK_CARD_DISPLAY = registerDisplay("dark_oak_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.DARK_OAK_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> CRIMSON_CARD_DISPLAY = registerDisplay("crimson_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.CRIMSON_PLANKS)));
+    public static final RegistryObject<CardDisplayBlock> WARPED_CARD_DISPLAY = registerDisplay("warped_card_display", () -> new CardDisplayBlock(BlockBehaviour.Properties.copy(Blocks.WARPED_PLANKS)));
     //Booster Boxes
     public static final RegistryObject<Block> BOOSTER_BOX_BASE = BuddycardsBlocks.BLOCKS.register("buddycard_booster_box_base", () -> new BuddycardBoosterBoxBlock(BuddycardsItems.DEFAULT_BUDDYCARD_REQUIREMENT, BuddycardsBlocks.BOOSTER_BOX_PROPERTIES));
     public static final RegistryObject<Block> BOOSTER_BOX_NETHER = BuddycardsBlocks.BLOCKS.register("buddycard_booster_box_nether", () -> new BuddycardBoosterBoxBlock(BuddycardsItems.DEFAULT_BUDDYCARD_REQUIREMENT, BuddycardsBlocks.BOOSTER_BOX_PROPERTIES));
     public static final RegistryObject<Block> BOOSTER_BOX_END = BuddycardsBlocks.BLOCKS.register("buddycard_booster_box_end", () -> new BuddycardBoosterBoxBlock(BuddycardsItems.DEFAULT_BUDDYCARD_REQUIREMENT, BuddycardsBlocks.BOOSTER_BOX_PROPERTIES));
     public static final RegistryObject<Block> BOOSTER_BOX_MYSTERY = BuddycardsBlocks.BLOCKS.register("buddycard_booster_box_mystery", () -> new BuddycardBoosterBoxBlock(BuddycardsItems.DEFAULT_BUDDYCARD_REQUIREMENT, BuddycardsBlocks.BOOSTER_BOX_PROPERTIES));
 
+    public static RegistryObject<CardDisplayBlock> registerDisplay(String id, Supplier<CardDisplayBlock> supplier) {
+        RegistryObject<CardDisplayBlock> display = BLOCKS.register(id, supplier);
+        DISPLAY_BLOCKS.add(display);
+        return display;
+    }
 }

--- a/src/main/java/com/wildcard/buddycards/registries/BuddycardsEntities.java
+++ b/src/main/java/com/wildcard/buddycards/registries/BuddycardsEntities.java
@@ -3,11 +3,14 @@ package com.wildcard.buddycards.registries;
 import com.wildcard.buddycards.Buddycards;
 import com.wildcard.buddycards.block.entity.CardDisplayBlockEntity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
+
+import java.util.function.Supplier;
 
 public class BuddycardsEntities {
     public static final DeferredRegister<BlockEntityType<?>> TILE_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, Buddycards.MOD_ID);
@@ -19,8 +22,8 @@ public class BuddycardsEntities {
     }
 
     public static final RegistryObject<BlockEntityType<CardDisplayBlockEntity>> CARD_DISPLAY_TILE = TILE_ENTITIES.register("card_display",
-            () -> BlockEntityType.Builder.of(CardDisplayBlockEntity::new, BuddycardsBlocks.OAK_CARD_DISPLAY.get(), BuddycardsBlocks.SPRUCE_CARD_DISPLAY.get(),
-                    BuddycardsBlocks.BIRCH_CARD_DISPLAY.get(), BuddycardsBlocks.JUNGLE_CARD_DISPLAY.get(), BuddycardsBlocks.ACACIA_CARD_DISPLAY.get(), BuddycardsBlocks.DARK_OAK_CARD_DISPLAY.get(),
-                    BuddycardsBlocks.CRIMSON_CARD_DISPLAY.get(), BuddycardsBlocks.WARPED_CARD_DISPLAY.get()).build(null));
-
+            () -> {
+                Block[] blocks = BuddycardsBlocks.DISPLAY_BLOCKS.stream().map(Supplier::get).toArray(Block[]::new);
+                return BlockEntityType.Builder.of(CardDisplayBlockEntity::new, blocks).build(null);
+            });
 }

--- a/src/main/java/com/wildcard/buddycards/registries/BuddycardsItems.java
+++ b/src/main/java/com/wildcard/buddycards/registries/BuddycardsItems.java
@@ -1,6 +1,7 @@
 package com.wildcard.buddycards.registries;
 
 import com.wildcard.buddycards.Buddycards;
+import com.wildcard.buddycards.core.BuddycardSet;
 import com.wildcard.buddycards.item.*;
 import net.minecraft.util.random.SimpleWeightedRandomList;
 import net.minecraft.world.item.BlockItem;
@@ -11,31 +12,37 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.Objects;
+
 public class BuddycardsItems {
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, Buddycards.MOD_ID);
 
     public static void registerItems() {
         //Register base set
-        registerCards("base", 1, 12, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("base", 13, 9, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("base", 22, 4, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("base", 26, 2, Rarity.EPIC, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("base", 28, 4, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("base", 32, 3, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("base", 35, 2, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(BASE_SET, 1, 12, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(BASE_SET, 13, 9, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(BASE_SET, 22, 4, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(BASE_SET, 26, 2, Rarity.EPIC, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(BASE_SET, 28, 4, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(BASE_SET, 32, 3, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(BASE_SET, 35, 2, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
         //Register nether set
-        registerCards("nether", 1, 12, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("nether", 13, 9, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("nether", 22, 4, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("nether", 26, 2, Rarity.EPIC, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(NETHER_SET, 1, 12, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(NETHER_SET, 13, 9, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(NETHER_SET, 22, 4, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(NETHER_SET, 26, 2, Rarity.EPIC, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
         //Register end set
-        registerCards("end", 1, 12, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("end", 13, 9, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("end", 22, 4, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
-        registerCards("end", 26, 2, Rarity.EPIC, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(END_SET, 1, 12, Rarity.COMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(END_SET, 13, 9, Rarity.UNCOMMON, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(END_SET, 22, 4, Rarity.RARE, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
+        registerCards(END_SET, 26, 2, Rarity.EPIC, DEFAULT_CARD_PROPERTIES, DEFAULT_BUDDYCARD_REQUIREMENT);
 
         ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
     }
+
+    public static final BuddycardSet BASE_SET = new BuddycardSet("base");
+    public static final BuddycardSet NETHER_SET = new BuddycardSet("nether");
+    public static final BuddycardSet END_SET = new BuddycardSet("end");
 
     //Default parameters
     public static final Item.Properties DEFAULT_PROPERTIES = new Item.Properties().tab(Buddycards.TAB);
@@ -57,9 +64,9 @@ public class BuddycardsItems {
             .build();
 
     //Packs
-    public static final RegistryObject<BuddycardPackItem> PACK_BASE = ITEMS.register("buddycard_pack_base", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "base", 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
-    public static final RegistryObject<BuddycardPackItem> PACK_NETHER = ITEMS.register("buddycard_pack_nether", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "nether", 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
-    public static final RegistryObject<BuddycardPackItem> PACK_END = ITEMS.register("buddycard_pack_end", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "end", 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
+    public static final RegistryObject<BuddycardPackItem> PACK_BASE = ITEMS.register("buddycard_pack_base", () -> new BuddycardSetPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, BASE_SET, 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
+    public static final RegistryObject<BuddycardPackItem> PACK_NETHER = ITEMS.register("buddycard_pack_nether", () -> new BuddycardSetPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, NETHER_SET, 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
+    public static final RegistryObject<BuddycardPackItem> PACK_END = ITEMS.register("buddycard_pack_end", () -> new BuddycardSetPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, END_SET, 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
     public static final RegistryObject<BuddycardPackItem> MYSTERY_PACK = ITEMS.register("buddycard_pack_mystery", () -> new MysteryBuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, 4, 1, DEFAULT_RARITY_WEIGHTS, false, RARE_PACK_PROPERTIES));
     //Binders
     public static final RegistryObject<BuddycardBinderItem> BINDER_BASE = ITEMS.register("buddycard_binder_base", () -> new BuddycardBinderItem(DEFAULT_BUDDYCARD_REQUIREMENT, DEFAULT_BINDER_PROPERTIES));
@@ -74,9 +81,9 @@ public class BuddycardsItems {
     public static final RegistryObject<BuddysteelPowerMeterItem> BUDDYSTEEL_POWER_METER = ITEMS.register("buddysteel_power_meter", () -> new BuddysteelPowerMeterItem(DEFAULT_UNCOMMON_PROPERTIES));
     //Medals
     public static final RegistryObject<BlankBuddysteelMedalItem> BLANK_BUDDYSTEEL_MEDAL = ITEMS.register("blank_buddysteel_medal", () -> new BlankBuddysteelMedalItem(BUDDYSTEEL_MEDAL_PROPERTIES));
-    public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_BASE = ITEMS.register("buddysteel_medal_base", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.BASE_SET, "base", DEFAULT_MEDAL_PROPERTIES));
-    public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_NETHER = ITEMS.register("buddysteel_medal_nether", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.NETHER_SET, "nether", DEFAULT_MEDAL_PROPERTIES));
-    public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_END = ITEMS.register("buddysteel_medal_end", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.END_SET, "end", DEFAULT_MEDAL_PROPERTIES));
+    public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_BASE = ITEMS.register("buddysteel_medal_base", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.BASE_SET, BASE_SET, DEFAULT_MEDAL_PROPERTIES));
+    public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_NETHER = ITEMS.register("buddysteel_medal_nether", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.NETHER_SET, NETHER_SET, DEFAULT_MEDAL_PROPERTIES));
+    public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_END = ITEMS.register("buddysteel_medal_end", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.END_SET, END_SET, DEFAULT_MEDAL_PROPERTIES));
     //Grading Sleeves
     public static final RegistryObject<GradingSleeveItem> GRADING_SLEEVE = ITEMS.register("grading_sleeve", () -> new GradingSleeveItem(DEFAULT_PROPERTIES, new float[]{0.4f, 0.3f, 0.225f, 0.073f}));
     public static final RegistryObject<GradingSleeveItem> GOLDEN_GRADING_SLEEVE = ITEMS.register("golden_grading_sleeve", () -> new GradingSleeveItem(DEFAULT_UNCOMMON_PROPERTIES, new float[]{0.1f, 0.4f, 0.3f, 0.195f}));
@@ -91,15 +98,16 @@ public class BuddycardsItems {
     public static final RegistryObject<BlockItem> CRIMSON_CARD_DISPLAY_ITEM = ITEMS.register("crimson_card_display", () -> new BlockItem(BuddycardsBlocks.CRIMSON_CARD_DISPLAY.get(), DEFAULT_PROPERTIES));
     public static final RegistryObject<BlockItem> WARPED_CARD_DISPLAY_ITEM = ITEMS.register("warped_card_display", () -> new BlockItem(BuddycardsBlocks.WARPED_CARD_DISPLAY.get(), DEFAULT_PROPERTIES));
     //Booster Box Items
-    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_BASE = ITEMS.register("buddycard_booster_box_base", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_BASE.get(), "base", DEFAULT_UNCOMMON_PROPERTIES));
-    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_NETHER = ITEMS.register("buddycard_booster_box_nether", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_NETHER.get(), "nether", DEFAULT_UNCOMMON_PROPERTIES));
-    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_END = ITEMS.register("buddycard_booster_box_end", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_END.get(), "end", DEFAULT_UNCOMMON_PROPERTIES));
-    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_MYSTERY = ITEMS.register("buddycard_booster_box_mystery", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_MYSTERY.get(), "mystery", DEFAULT_EPIC_PROPERTIES));
+    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_BASE = ITEMS.register("buddycard_booster_box_base", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_BASE.get(), PACK_BASE, DEFAULT_UNCOMMON_PROPERTIES));
+    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_NETHER = ITEMS.register("buddycard_booster_box_nether", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_NETHER.get(), PACK_NETHER, DEFAULT_UNCOMMON_PROPERTIES));
+    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_END = ITEMS.register("buddycard_booster_box_end", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_END.get(), PACK_END, DEFAULT_UNCOMMON_PROPERTIES));
+    public static final RegistryObject<BuddycardBoosterBoxItem> BOOSTER_BOX_MYSTERY = ITEMS.register("buddycard_booster_box_mystery", () -> new BuddycardBoosterBoxItem(BuddycardsBlocks.BOOSTER_BOX_MYSTERY.get(), MYSTERY_PACK, DEFAULT_EPIC_PROPERTIES));
 
     //Card registration
-    public static void registerCards(String set, int startValue, int amount, Rarity rarity, Item.Properties properties, BuddycardRequirement requirement) {
+    public static void registerCards(BuddycardSet set, int startValue, int amount, Rarity rarity, Item.Properties properties, BuddycardRequirement requirement) {
+        Objects.requireNonNull(set);
         for (int i = startValue; i < amount + startValue; i++) {
-            ITEMS.register("buddycard_" + set + i, new BuddycardItem(requirement, set, i, rarity, properties).delegate);
+            ITEMS.register("buddycard_" + set.getName() + i, new BuddycardItem(requirement, set, i, rarity, properties).delegate);
         }
     }
 

--- a/src/main/java/com/wildcard/buddycards/registries/BuddycardsItems.java
+++ b/src/main/java/com/wildcard/buddycards/registries/BuddycardsItems.java
@@ -2,6 +2,7 @@ package com.wildcard.buddycards.registries;
 
 import com.wildcard.buddycards.Buddycards;
 import com.wildcard.buddycards.item.*;
+import net.minecraft.util.random.SimpleWeightedRandomList;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Rarity;
@@ -48,12 +49,18 @@ public class BuddycardsItems {
     public static final Item.Properties DEFAULT_MEDAL_PROPERTIES = new Item.Properties().tab(Buddycards.TAB).stacksTo(1).rarity(Rarity.UNCOMMON);
     public static final Item.Properties BUDDYSTEEL_MEDAL_PROPERTIES = new Item.Properties().tab(Buddycards.TAB).stacksTo(1).rarity(Rarity.COMMON);
     public static final BuddycardRequirement DEFAULT_BUDDYCARD_REQUIREMENT = () -> true;
+    public static final SimpleWeightedRandomList<Rarity> DEFAULT_RARITY_WEIGHTS = SimpleWeightedRandomList.<Rarity>builder()
+            .add(Rarity.COMMON, 24)
+            .add(Rarity.UNCOMMON, 12)
+            .add(Rarity.RARE, 3)
+            .add(Rarity.EPIC, 1)
+            .build();
 
     //Packs
-    public static final RegistryObject<BuddycardPackItem> PACK_BASE = ITEMS.register("buddycard_pack_base", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "base", 4, 1, DEFAULT_PACK_PROPERTIES));
-    public static final RegistryObject<BuddycardPackItem> PACK_NETHER = ITEMS.register("buddycard_pack_nether", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "nether", 4, 1, DEFAULT_PACK_PROPERTIES));
-    public static final RegistryObject<BuddycardPackItem> PACK_END = ITEMS.register("buddycard_pack_end", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "end", 4, 1, DEFAULT_PACK_PROPERTIES));
-    public static final RegistryObject<BuddycardPackItem> MYSTERY_PACK = ITEMS.register("buddycard_pack_mystery", () -> new MysteryBuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, 4, 1, false, RARE_PACK_PROPERTIES));
+    public static final RegistryObject<BuddycardPackItem> PACK_BASE = ITEMS.register("buddycard_pack_base", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "base", 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
+    public static final RegistryObject<BuddycardPackItem> PACK_NETHER = ITEMS.register("buddycard_pack_nether", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "nether", 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
+    public static final RegistryObject<BuddycardPackItem> PACK_END = ITEMS.register("buddycard_pack_end", () -> new BuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, "end", 4, 1, DEFAULT_RARITY_WEIGHTS, DEFAULT_PACK_PROPERTIES));
+    public static final RegistryObject<BuddycardPackItem> MYSTERY_PACK = ITEMS.register("buddycard_pack_mystery", () -> new MysteryBuddycardPackItem(DEFAULT_BUDDYCARD_REQUIREMENT, 4, 1, DEFAULT_RARITY_WEIGHTS, false, RARE_PACK_PROPERTIES));
     //Binders
     public static final RegistryObject<BuddycardBinderItem> BINDER_BASE = ITEMS.register("buddycard_binder_base", () -> new BuddycardBinderItem(DEFAULT_BUDDYCARD_REQUIREMENT, DEFAULT_BINDER_PROPERTIES));
     public static final RegistryObject<BuddycardBinderItem> BINDER_NETHER = ITEMS.register("buddycard_binder_nether", () -> new BuddycardBinderItem(DEFAULT_BUDDYCARD_REQUIREMENT, DEFAULT_BINDER_PROPERTIES));
@@ -71,9 +78,9 @@ public class BuddycardsItems {
     public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_NETHER = ITEMS.register("buddysteel_medal_nether", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.NETHER_SET, "nether", DEFAULT_MEDAL_PROPERTIES));
     public static final RegistryObject<BuddysteelSetMedalItem> MEDAL_END = ITEMS.register("buddysteel_medal_end", () -> new BuddysteelSetMedalItem(DEFAULT_BUDDYCARD_REQUIREMENT, MedalTypes.END_SET, "end", DEFAULT_MEDAL_PROPERTIES));
     //Grading Sleeves
-    public static final RegistryObject<GradingSleeveItem> GRADING_SLEEVE = ITEMS.register("grading_sleeve", () -> new GradingSleeveItem(DEFAULT_PROPERTIES, new float[]{0.4f,0.3f,0.225f,0.073f}));
-    public static final RegistryObject<GradingSleeveItem> GOLDEN_GRADING_SLEEVE = ITEMS.register("golden_grading_sleeve", () -> new GradingSleeveItem(DEFAULT_UNCOMMON_PROPERTIES, new float[]{0.1f,0.4f,0.3f,0.195f}));
-    public static final RegistryObject<GradingSleeveItem> CREATIVE_GRADING_SLEEVE = ITEMS.register("creative_grading_sleeve", () -> new CreativeGradingSleeveItem(DEFAULT_EPIC_PROPERTIES, new float[]{0.1f,0.4f,0.3f,0.19f}));
+    public static final RegistryObject<GradingSleeveItem> GRADING_SLEEVE = ITEMS.register("grading_sleeve", () -> new GradingSleeveItem(DEFAULT_PROPERTIES, new float[]{0.4f, 0.3f, 0.225f, 0.073f}));
+    public static final RegistryObject<GradingSleeveItem> GOLDEN_GRADING_SLEEVE = ITEMS.register("golden_grading_sleeve", () -> new GradingSleeveItem(DEFAULT_UNCOMMON_PROPERTIES, new float[]{0.1f, 0.4f, 0.3f, 0.195f}));
+    public static final RegistryObject<GradingSleeveItem> CREATIVE_GRADING_SLEEVE = ITEMS.register("creative_grading_sleeve", () -> new CreativeGradingSleeveItem(DEFAULT_EPIC_PROPERTIES, new float[]{0.1f, 0.4f, 0.3f, 0.19f}));
     //Card Display Items
     public static final RegistryObject<BlockItem> OAK_CARD_DISPLAY_ITEM = ITEMS.register("oak_card_display", () -> new BlockItem(BuddycardsBlocks.OAK_CARD_DISPLAY.get(), DEFAULT_PROPERTIES));
     public static final RegistryObject<BlockItem> SPRUCE_CARD_DISPLAY_ITEM = ITEMS.register("spruce_card_display", () -> new BlockItem(BuddycardsBlocks.SPRUCE_CARD_DISPLAY.get(), DEFAULT_PROPERTIES));
@@ -91,7 +98,7 @@ public class BuddycardsItems {
 
     //Card registration
     public static void registerCards(String set, int startValue, int amount, Rarity rarity, Item.Properties properties, BuddycardRequirement requirement) {
-        for(int i = startValue; i < amount + startValue; i++) {
+        for (int i = startValue; i < amount + startValue; i++) {
             ITEMS.register("buddycard_" + set + i, new BuddycardItem(requirement, set, i, rarity, properties).delegate);
         }
     }

--- a/src/main/java/com/wildcard/buddycards/util/ClientStuff.java
+++ b/src/main/java/com/wildcard/buddycards/util/ClientStuff.java
@@ -2,6 +2,8 @@ package com.wildcard.buddycards.util;
 
 import com.wildcard.buddycards.Buddycards;
 import com.wildcard.buddycards.client.renderer.CardDisplayBlockRenderer;
+import com.wildcard.buddycards.core.BuddycardSet;
+import com.wildcard.buddycards.core.BuddycardsAPI;
 import com.wildcard.buddycards.item.BuddycardItem;
 import com.wildcard.buddycards.registries.BuddycardsEntities;
 import com.wildcard.buddycards.registries.BuddycardsItems;
@@ -24,8 +26,8 @@ public class ClientStuff {
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent event) {
         event.enqueueWork(() -> MenuScreens.register(BuddycardsMisc.BINDER_CONTAINER.get(), BinderScreen::new));
-        for (ArrayList<BuddycardItem> set : BuddycardItem.CARD_LIST.values()) {
-            for (BuddycardItem card : set) {
+        for (BuddycardSet set : BuddycardsAPI.getAllCardsets()) {
+            for (BuddycardItem card : set.getCards()) {
                 event.enqueueWork(() -> ItemProperties.register(card, new ResourceLocation("grade"), (stack, world, entity, idk) -> {
                     if (stack.getTag() != null)
                         return stack.getTag().getInt("grade");

--- a/src/main/java/com/wildcard/buddycards/util/CuriosIntegration.java
+++ b/src/main/java/com/wildcard/buddycards/util/CuriosIntegration.java
@@ -3,7 +3,6 @@ package com.wildcard.buddycards.util;
 import com.wildcard.buddycards.Buddycards;
 import com.wildcard.buddycards.client.renderer.MedalRenderer;
 import com.wildcard.buddycards.item.IMedalTypes;
-import com.wildcard.buddycards.item.MedalTypes;
 import com.wildcard.buddycards.registries.BuddycardsItems;
 import com.wildcard.buddycards.registries.BuddycardsMisc;
 import net.minecraft.core.Direction;
@@ -57,6 +56,7 @@ public class CuriosIntegration {
 
         return new ICapabilityProvider() {
             private final LazyOptional<ICurio> curioOpt = LazyOptional.of(() -> curio);
+
             @Nonnull
             @Override
             public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
@@ -72,8 +72,12 @@ public class CuriosIntegration {
     }
 
     public static void setupRenderers() {
-        CuriosRendererRegistry.register(BuddycardsItems.MEDAL_BASE.get(), () -> new MedalRenderer("buddysteel_medal_base"));
-        CuriosRendererRegistry.register(BuddycardsItems.MEDAL_NETHER.get(), () -> new MedalRenderer("buddysteel_medal_nether"));
-        CuriosRendererRegistry.register(BuddycardsItems.MEDAL_END.get(), () -> new MedalRenderer("buddysteel_medal_end"));
+        CuriosRendererRegistry.register(BuddycardsItems.MEDAL_BASE.get(), () -> new MedalRenderer(getDefaultMedalTexture("buddysteel_medal_base")));
+        CuriosRendererRegistry.register(BuddycardsItems.MEDAL_NETHER.get(), () -> new MedalRenderer(getDefaultMedalTexture("buddysteel_medal_nether")));
+        CuriosRendererRegistry.register(BuddycardsItems.MEDAL_END.get(), () -> new MedalRenderer(getDefaultMedalTexture("buddysteel_medal_end")));
+    }
+
+    protected static ResourceLocation getDefaultMedalTexture(String name) {
+        return new ResourceLocation(Buddycards.MOD_ID, "textures/models/medal/" + name + ".png");
     }
 }


### PR DESCRIPTION
Hey,

the PR contains multiple things to help making expansions.

1. Custom CardDisplays. `CardDisplayBlockEntity` now uses `BuddycardsBlocks::DISPLAY_BLOCKS` to get the needed blocks. So expansions can use `BuddycardsBlocks::registerDisplay` to register their displays.
2. Change a lot of private field to protected for inheritance 
3. `MedalRenderer` uses now a `ResourceLocation` for mod based resource paths
4. Random -> Rarity weights. Helps to create sets where some rarities does not exist without implementing some custom behavior. Pack creation fails if no weights set. Also crashes if weights contains a rarity which does not exist in the card set. 
5. Replace `String set` with `BuddycardSet set`. Every set now knows his medal and the cards and also provides the descriptions id for translation.